### PR TITLE
Fix links and update to latest template

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 # NCAR Dask Tutorial
 
-[![nightly-build](https://github.com/ProjectPythia/cookbook-template/actions/workflows/nightly-build.yaml/badge.svg)](https://github.com/ProjectPythia/cookbook-template/actions/workflows/nightly-build.yaml)
-[![Binder](https://mybinder.org/badge_logo.svg)](http://binder.projectpythia.org/v2/gh/ProjectPythia/dask-cookbook/main?labpath=notebooks)
+[![nightly-build](https://github.com/ProjectPythia/dask-cookbook/actions/workflows/nightly-build.yaml/badge.svg)](https://github.com/ProjectPythia/dask-cookbook/actions/workflows/nightly-build.yaml)
+[![Binder](https://binder.projectpythia.org/badge_logo.svg)](https://binder.projectpythia.org/v2/gh/ProjectPythia/dask-cookbook/main?labpath=notebooks)
 [![DOI](https://zenodo.org/badge/610934658.svg)](https://zenodo.org/badge/latestdoi/610934658)
 
 This Project Pythia Cookbook provides a comprehensive guide to understanding the basic concepts and collections of Dask as well as its integration with Xarray.
@@ -39,12 +39,12 @@ Finally, we will discuss some best practices regarding Dask + Xarray.
 
 ## Running the Notebooks
 
-You can either run the notebook using [Binder](https://mybinder.org/) or on your local machine.
+You can either run the notebook using [Binder](https://binder.projectpythia.org/) or on your local machine.
 
 ### Running on Binder
 
 The simplest way to interact with a Jupyter Notebook is through
-[Binder](https://mybinder.org/), which enables the execution of a
+[Binder](https://binder.projectpythia.org/), which enables the execution of a
 [Jupyter Book](https://jupyterbook.org) in the cloud. The details of how this works are not
 important for now. All you need to know is how to launch a Pythia
 Cookbooks chapter via Binder. Simply navigate your mouse to
@@ -78,7 +78,7 @@ If you are interested in running this material locally on your computer, you wil
 
    ```bash
    conda env create -f environment.yml
-   conda activate dask-cookbook-example
+   conda activate dask-cookbook-dev
    ```
 
 1. Move into the `notebooks` directory and start up Jupyterlab

--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,9 @@ sphinx:
   config:
     linkcheck_ignore: ["https://doi.org/*", "https://zenodo.org/badge/*"] # don't run link checker on DOI links since they are immutable
     nb_execution_raise_on_error: true # raise exception in build if there are notebook errors (this flag is ignored if building on binder)
+    linkcheck_request_headers:
+       "https://*.noaa.gov/":
+         User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:24.0) Gecko/20100101 Firefox/24.0
     html_favicon: notebooks/images/icons/favicon.ico
     html_last_updated_fmt: "%-d %B %Y"
     html_theme: sphinx_pythia_theme

--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,8 @@ parse:
 
 sphinx:
   config:
+    linkcheck_ignore: ["https://doi.org/*", "https://zenodo.org/badge/*"] # don't run link checker on DOI links since they are immutable
+    nb_execution_raise_on_error: true # raise exception in build if there are notebook errors (this flag is ignored if building on binder)
     html_favicon: notebooks/images/icons/favicon.ico
     html_last_updated_fmt: "%-d %B %Y"
     html_theme: sphinx_pythia_theme
@@ -47,7 +49,7 @@ sphinx:
           icon: fab fa-youtube-square
           type: fontawesome
       launch_buttons:
-        binderhub_url: http://binder.mypythia.org
+        binderhub_url: https://binder.projectpythia.org
         notebook_interface: jupyterlab
       extra_navbar: |
         Theme by <a href="https://projectpythia.org">Project Pythia</a>.<br><br>


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Fixes a bunch of obsolete links to previous Pythia binder, and gets this cookbook up to date with the latest template.

The nightly-build badge is currently pointing to the wrong build (Cookbook Template). This PR fixes that. it will also fix the broken Binder link that appears in the Gallery.