### PR TITLE
Update _config.yml to add linkcheck_ignore

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,6 +27,7 @@ parse:
 
 sphinx:
   config:
+    linkcheck_ignore: ["https://www.ncdc.noaa.gov/cdo-web/search?*"] # don't run link checker on NOAA CDO search link
     html_favicon: notebooks/images/icons/favicon.ico
     html_last_updated_fmt: "%-d %B %Y"
     html_theme: sphinx_pythia_theme

--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ parse:
 
 sphinx:
   config:
-    linkcheck_ignore: ["https://www.ncdc.noaa.gov/cdo-web/search?*"] # don't run link checker on NOAA CDO search link
+    linkcheck_ignore: ["https://www.ncdc.noaa.gov/cdo-web/*"] # don't run link checker on NOAA CDO search link
     html_favicon: notebooks/images/icons/favicon.ico
     html_last_updated_fmt: "%-d %B %Y"
     html_theme: sphinx_pythia_theme

--- a/notebooks/03-dask-xarray.ipynb
+++ b/notebooks/03-dask-xarray.ipynb
@@ -952,7 +952,7 @@
     "*  [Dask Code](https://github.com/dask/dask/)\n",
     "*  [Dask Blog](https://blog.dask.org/)\n",
     "*  [Xarray Docs](https://xarray.pydata.org/)\n",
-    "*  [Xarray + Dask docs](https://docs.xarray.dev/en/stable/user-guide/dask.html), particularly the [optimization tips](https://docs.xarray.dev/en/stable/user-guide/dask.html#optimization-tips)\n",
+    "*  [Xarray + Dask docs](https://docs.xarray.dev/en/stable/user-guide/dask.html), particularly the [best practices](https://docs.xarray.dev/en/stable/user-guide/dask.html#best-practices)\n",
     "* [Xarray Tutorial material](https://tutorial.xarray.dev/intro.html)\n",
     "  \n",
     "\n",


### PR DESCRIPTION
Closes #19 

Add a `linkcheck_ignore` to _config.yml for "https://www.ncdc.noaa.gov/cdo-web/search?datasetid=GHCND" since the linkcheck issue seems to be because of this, while there is no actual problem with the NOAA's URL.

Also, change a xarray-docs URL from the optimization-tips anchor to a best-practices one since the former no longer exists in the Xarray docs.