### PR TITLE
fix matplotlib string output and starting logo

### DIFF
--- a/notebooks/03-dask-xarray.ipynb
+++ b/notebooks/03-dask-xarray.ipynb
@@ -7,18 +7,17 @@
     "tags": []
    },
    "source": [
+    "\n",
+    "# Parallelizing Xarray with Dask\n",
+    "\n",
     "<img src=\"https://docs.dask.org/en/stable/_images/dask_horizontal.svg\"\n",
     "     width=\"30%\"\n",
     "     alt=\"Dask logo\"\n",
-    "     align=\"right\"\n",
     "/>\n",
     "<img src=\"https://docs.xarray.dev/en/latest/_images/dataset-diagram.png\"\n",
     "     width=\"30%\"\n",
     "     alt=\"Xarray\"\n",
-    "     align=\"right\"\n",
     "/>\n",
-    "\n",
-    "# Parallelizing Xarray with Dask\n",
     "\n",
     "### In this tutorial, you learn:\n",
     "\n",
@@ -697,7 +696,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tb.plot()"
+    "tb.plot();"
    ]
   },
   {
@@ -771,7 +770,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tos_anom.sel(lon=310, lat=50, method='nearest').plot( size=4)"
+    "tos_anom.sel(lon=310, lat=50, method='nearest').plot( size=4);"
    ]
   },
   {
@@ -781,7 +780,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tos_anom.sel(time='2030-01-01').plot()"
+    "tos_anom.sel(time='2030-01-01').plot();"
    ]
   },
   {


### PR DESCRIPTION
<img width="635" height="247" alt="Screenshot 2026-03-04 at 9 55 45 AM" src="https://github.com/user-attachments/assets/38077e83-ce1a-4cda-8453-57c37a95b249" />

Not sure why the logo is squished, but it needs to be after the title, also added `;` to .plot() calls.
JS2 Binder is currently down due to a failed kubernetes upgrade so this will likely fail until that is resolved.